### PR TITLE
modify reset pw url, add adminVerified to updateUser

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -2,4 +2,4 @@ export const JWT_SECRET = 'is4103';
 export const ALLOWED_DOCUMENT_FILE_TYPES = ['.docx', '.pdf', '.doc'];
 export const ALLOWED_IMG_FILE_TYPES = ['.jpeg', '.jpg', '.png'];
 export const BACKEND_API = 'http://localhost:5000/api';
-export const RESET_PASSWORD_URL = 'http://localhost:3000';
+export const RESET_PASSWORD_URL = 'http://localhost:3000/auth';

--- a/src/routes/schema/user.schema.ts
+++ b/src/routes/schema/user.schema.ts
@@ -1,5 +1,6 @@
 import joi, { string } from 'joi';
 import { PRIVACY_PERMISSIONS_ENUM } from '../../constants/enum';
+import { ADMIN_VERIFIED_ENUM } from '../../constants/enum';
 
 export default {
   accountIdQ: joi.object({
@@ -47,6 +48,7 @@ export default {
       emailNotification: joi.boolean(),
       occupation: joi.string(),
       industry: joi.string(),
+      adminVerified: joi.string().valid(...Object.values(ADMIN_VERIFIED_ENUM)),
     }),
   }),
   updateUserOccupationB: joi.object({


### PR DESCRIPTION
### Changelog:
added /auth/ to reset password url
adminVerified added to list of attr allowed for updateUser

## Description:
Modify reset password link to match frontend /auth/ page
Need adminVerified attribute so that Sensei can manually request for Profile approval (one-time)
Intended action:
SHELL > PENDING
REJECTED > PENDING

## Checklist:
- [ ] Merged latest develop
- [ ] PR title makes sense

## Screenshots (where relevant):
<img width="314" alt="image" src="https://user-images.githubusercontent.com/43084055/109598959-4f6e5700-7b55-11eb-94ea-25b4cd875f24.png">
<img width="318" alt="image" src="https://user-images.githubusercontent.com/43084055/109599106-98261000-7b55-11eb-903e-ac7254f9e2c1.png">
<img width="312" alt="image" src="https://user-images.githubusercontent.com/43084055/109599147-aaa04980-7b55-11eb-96f6-f419c0522697.png">
<img width="308" alt="image" src="https://user-images.githubusercontent.com/43084055/109599168-b55ade80-7b55-11eb-83d1-36e65be0b997.png">
