### PR TITLE
Bugfix: include unauthorised wallet check in code-block for non-admin users

### DIFF
--- a/src/services/wallet.service.ts
+++ b/src/services/wallet.service.ts
@@ -125,9 +125,9 @@ export default class WalletService {
     let user;
     if (userType !== USER_TYPE_ENUM.ADMIN) {
       user = await User.findByPk(accountId);
+      if (!user || user.walletId !== walletId)
+        throw new Error(WALLET_ERROR.UNAUTH_WALLET);
     }
-    if (!user || user.walletId !== walletId)
-      throw new Error(WALLET_ERROR.UNAUTH_WALLET);
 
     return await Wallet.findByPk(walletId, {
       include: [


### PR DESCRIPTION
### Changelog:
- see commit log
## Description:
- allow viewWallet endpoint to be used by admins that have SUPERADMIN/FINANCE role
- issue was that when an admin used viewWallet, it got the UNAUTH_WALLET error as user object is falsey
- only non-admins need this check; admins don't need this check as they can view anyone's wallet

**Note:** this fix was discussed with ian, am only making a PR for it as it is a minor change and ian is currently afk
## Checklist:
- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):
of issue
<img width="939" alt="Screenshot 2021-03-29 at 10 39 24 AM" src="https://user-images.githubusercontent.com/41737751/112782612-0213d580-9080-11eb-8802-8882930c126c.png">
![Screenshot 2021-03-29 at 10 38 45 AM](https://user-images.githubusercontent.com/41737751/112782620-063ff300-9080-11eb-9be9-f3ec073b8c60.png)