### PR TITLE
Fix concurrency issue for update sensei

### DIFF
--- a/src/services/wallet.service.ts
+++ b/src/services/wallet.service.ts
@@ -52,12 +52,6 @@ export default class WalletService {
     status: BILLING_STATUS,
     billingType: BILLING_TYPE
   ) {
-    const senseiWallet = await Wallet.findByPk(senseiWalletId);
-    const pendingAmount = senseiWallet.pendingAmount + amount;
-    const totalEarned = senseiWallet.totalEarned + amount;
-
-    await senseiWallet.update({ pendingAmount, totalEarned });
-
     const withdrawableDate = new Date();
     withdrawableDate.setDate(withdrawableDate.getDate() + WITHDRAWAL_DAYS);
 


### PR DESCRIPTION
### Changelog:
## Description:
- concurrency issue when updating sensei wallet - multiple hits to the same record resulting in only one updating it.
## Checklist:
- [x] Merged latest develop
- [ ] PR title makes sense

## Screenshots (where relevant):
