### PR TITLE
update database init issue due to UserFollowership foreign key

### DIFF
--- a/src/models/UserFollowership.ts
+++ b/src/models/UserFollowership.ts
@@ -20,12 +20,10 @@ export class UserFollowership extends Model<UserFollowership> {
   @Column(DataType.UUID)
   followershipId: string;
 
-  @ForeignKey(() => User)
-  @Column
+  @Column(DataType.UUID)
   followerId: string;
 
-  @ForeignKey(() => User)
-  @Column
+  @Column(DataType.UUID)
   followingId: string;
 
   @Column({
@@ -44,9 +42,19 @@ export class UserFollowership extends Model<UserFollowership> {
   updatedAt: Date;
 
   // ==================== RELATIONSHIP MAPPINGS ====================
-  @BelongsTo(() => User, 'followerId')
+  @BelongsTo(() => User, {
+    foreignKey: {
+      name: 'followerId',
+      allowNull: false,
+    },
+  })
   Following: User;
 
-  @BelongsTo(() => User, 'followingId')
+  @BelongsTo(() => User, {
+    foreignKey: {
+      name: 'followerId',
+      allowNull: false,
+    },
+  })
   Follower: User;
 }

--- a/src/models/UserFollowership.ts
+++ b/src/models/UserFollowership.ts
@@ -52,7 +52,7 @@ export class UserFollowership extends Model<UserFollowership> {
 
   @BelongsTo(() => User, {
     foreignKey: {
-      name: 'followerId',
+      name: 'followingId',
       allowNull: false,
     },
   })

--- a/src/services/social.service.ts
+++ b/src/services/social.service.ts
@@ -326,6 +326,7 @@ export default class SocialService {
           },
           attributes: [
             'accountId',
+            'username',
             'firstName',
             'lastName',
             'profileImgUrl',
@@ -371,6 +372,7 @@ export default class SocialService {
           },
           attributes: [
             'accountId',
+            'username',
             'firstName',
             'lastName',
             'profileImgUrl',

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -56,6 +56,7 @@ export default class UserService {
         const privateUser = await User.findByPk(accountId, {
           attributes: [
             'accountId',
+            'username',
             'firstName',
             'lastName',
             'profileImgUrl',


### PR DESCRIPTION
### Changelog:

update foreign key specification for UserFollowership table to use declaration statement in the Relationship Mapping portion

## Description:

Fix issue whereby `yarn start-dev` encounters an error due to UserFollowership foreign key mismatch.

## Checklist:
- [ ] Merged latest develop
- [ ] PR title makes sense

## Screenshots (where relevant):
![2021-04-03 00 32 46](https://user-images.githubusercontent.com/43084055/113434767-240caf80-9414-11eb-96da-029bc7ac1d0a.jpg)
