### PR TITLE
Paypal refactoring

### DIFF
--- a/src/controllers/wallet.controller.ts
+++ b/src/controllers/wallet.controller.ts
@@ -1,7 +1,10 @@
 import httpStatusCodes from 'http-status-codes';
 import logger from '../config/logger';
-import { RESPONSE_ERROR, WALLET_ERROR } from '../constants/errors';
-import { WITHDRAWAL_RESPONSE } from '../constants/successMessages';
+import { ERRORS, RESPONSE_ERROR, WALLET_ERROR } from '../constants/errors';
+import {
+  REFUND_RESPONSE,
+  WITHDRAWAL_RESPONSE,
+} from '../constants/successMessages';
 import Utility from '../constants/utility';
 import WalletService from '../services/wallet.service';
 import apiResponse from '../utilities/apiResponse';
@@ -17,7 +20,7 @@ export class WalletController {
         httpStatusCodes.OK
       );
     } catch (e) {
-      logger.error('[walletController.viewBillingsByFilter]:' + e.message);
+      logger.error('[WalletController.viewBillingsByFilter]:' + e.message);
       return apiResponse.error(res, httpStatusCodes.BAD_REQUEST, {
         message: e.message,
       });
@@ -37,7 +40,7 @@ export class WalletController {
         httpStatusCodes.OK
       );
     } catch (e) {
-      logger.error('[walletController.viewListOfWallets]:' + e.message);
+      logger.error('[WalletController.viewListOfWallets]:' + e.message);
       return apiResponse.error(res, httpStatusCodes.INTERNAL_SERVER_ERROR, {
         message: RESPONSE_ERROR.RES_ERROR,
       });
@@ -60,11 +63,59 @@ export class WalletController {
         httpStatusCodes.OK
       );
     } catch (e) {
-      logger.error('[walletController.viewWallet]:' + e.message);
+      logger.error('[WalletController.viewWallet]:' + e.message);
       return Utility.apiErrorResponse(res, e, [WALLET_ERROR.UNAUTH_WALLET]);
     }
   }
 
+  // ============================== Refund ==============================
+  public static async cancelRefundRequest(req, res) {
+    try {
+      const { refundRequestId } = req.params;
+      const { user } = req;
+      await WalletService.cancelRefundRequest(refundRequestId, user.accountId);
+      return apiResponse.result(
+        res,
+        { message: REFUND_RESPONSE.REQUEST_CANCEL },
+        httpStatusCodes.OK
+      );
+    } catch (e) {
+      logger.error('[WalletController.requestRefund]:' + e.message);
+      return Utility.apiErrorResponse(res, e, [
+        ERRORS.STUDENT_DOES_NOT_EXIST,
+        WALLET_ERROR.REFUNDED,
+        WALLET_ERROR.EXISTING_REFUND,
+        WALLET_ERROR.REFUND_PERIOD_OVER,
+      ]);
+    }
+  }
+
+  public static async requestRefund(req, res) {
+    try {
+      const { contractId, contractType } = req.query;
+      const { user } = req;
+      const refundRequest = await WalletService.requestRefund(
+        contractId,
+        contractType,
+        user.accountId
+      );
+      return apiResponse.result(
+        res,
+        { message: REFUND_RESPONSE.REQUEST_CREATE, refundRequest },
+        httpStatusCodes.OK
+      );
+    } catch (e) {
+      logger.error('[WalletController.requestRefund]:' + e.message);
+      return Utility.apiErrorResponse(res, e, [
+        ERRORS.STUDENT_DOES_NOT_EXIST,
+        WALLET_ERROR.REFUNDED,
+        WALLET_ERROR.EXISTING_REFUND,
+        WALLET_ERROR.REFUND_PERIOD_OVER,
+      ]);
+    }
+  }
+
+  // ============================== Withdrawal ==============================
   public static async withdrawBalance(req, res) {
     try {
       const { user } = req;
@@ -79,7 +130,7 @@ export class WalletController {
         httpStatusCodes.OK
       );
     } catch (e) {
-      logger.error('[walletController.withdrawBalance]:' + e.message);
+      logger.error('[WalletController.withdrawBalance]:' + e.message);
       return Utility.apiErrorResponse(res, e, [
         WALLET_ERROR.UNAUTH_WALLET,
         WALLET_ERROR.NO_MONEY,
@@ -97,7 +148,7 @@ export class WalletController {
         httpStatusCodes.OK
       );
     } catch (e) {
-      logger.error('[walletController.manualChronjob]:' + e.message);
+      logger.error('[WalletController.manualChronjob]:' + e.message);
       return apiResponse.error(res, httpStatusCodes.INTERNAL_SERVER_ERROR, {
         message: e.message,
       });

--- a/src/routes/admin.route.ts
+++ b/src/routes/admin.route.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import Utility from '../constants/utility';
 import { AdminController } from '../controllers/admin.controller';
+import { PaypalController } from '../controllers/paypal.controller';
 import { WalletController } from '../controllers/wallet.controller';
 import {
   requireAdmin,
@@ -189,7 +190,7 @@ router.post(
   passport.authenticate('isAuthenticated', { session: false }),
   requireFinance,
   schemaValidator.params(wallet.billingIdP),
-  Utility.asyncHandler(AdminController.approveWithdrawal)
+  Utility.asyncHandler(PaypalController.approveWithdrawal)
 );
 // reject withdrawal
 router.put(
@@ -197,7 +198,7 @@ router.put(
   passport.authenticate('isAuthenticated', { session: false }),
   requireFinance,
   schemaValidator.params(wallet.billingIdP),
-  Utility.asyncHandler(AdminController.rejectWithdrawal)
+  Utility.asyncHandler(PaypalController.rejectWithdrawal)
 );
 
 // approve refund
@@ -206,7 +207,7 @@ router.post(
   passport.authenticate('isAuthenticated', { session: false }),
   requireFinance,
   schemaValidator.params(wallet.refundRequestIdP),
-  Utility.asyncHandler(AdminController.approveRefund)
+  Utility.asyncHandler(PaypalController.approveRefund)
 );
 // reject refund
 router.put(
@@ -214,6 +215,6 @@ router.put(
   passport.authenticate('isAuthenticated', { session: false }),
   requireFinance,
   schemaValidator.params(wallet.refundRequestIdP),
-  Utility.asyncHandler(AdminController.rejectRefund)
+  Utility.asyncHandler(PaypalController.rejectRefund)
 );
 export default router;

--- a/src/routes/paypal.route.ts
+++ b/src/routes/paypal.route.ts
@@ -5,7 +5,6 @@ import { PaypalController } from '../controllers/paypal.controller';
 import { requireStudent } from '../middlewares/authenticationMiddleware';
 import cart from './schema/cart.schema';
 import paypal from './schema/paypal.schema';
-import wallet from './schema/wallet.schema';
 
 const router = express.Router();
 
@@ -40,21 +39,5 @@ router.get(
   requireStudent,
   schemaValidator.params(paypal.paymentIdP),
   Utility.asyncHandler(PaypalController.viewOrder)
-);
-
-router.post(
-  '/refund',
-  passport.authenticate('isAuthenticated', { session: false }),
-  requireStudent,
-  schemaValidator.query(wallet.refundRequestQ),
-  Utility.asyncHandler(PaypalController.requestRefund)
-);
-
-router.delete(
-  '/refund/:refundRequestId',
-  passport.authenticate('isAuthenticated', { session: false }),
-  requireStudent,
-  schemaValidator.params(wallet.refundRequestIdP),
-  Utility.asyncHandler(PaypalController.cancelRefundRequest)
 );
 export default router;

--- a/src/routes/wallet.route.ts
+++ b/src/routes/wallet.route.ts
@@ -5,6 +5,7 @@ import { WalletController } from '../controllers/wallet.controller';
 import {
   requireFinanceIfAdmin,
   requireSensei,
+  requireStudent,
 } from '../middlewares/authenticationMiddleware';
 import wallet from './schema/wallet.schema';
 
@@ -37,6 +38,22 @@ router.get(
   requireFinanceIfAdmin,
   schemaValidator.query(wallet.billingFilterQ),
   Utility.asyncHandler(WalletController.viewBillingsByFilter)
+);
+
+router.post(
+  '/refund',
+  passport.authenticate('isAuthenticated', { session: false }),
+  requireStudent,
+  schemaValidator.query(wallet.refundRequestQ),
+  Utility.asyncHandler(WalletController.requestRefund)
+);
+
+router.delete(
+  '/refund/:refundRequestId',
+  passport.authenticate('isAuthenticated', { session: false }),
+  requireStudent,
+  schemaValidator.params(wallet.refundRequestIdP),
+  Utility.asyncHandler(WalletController.cancelRefundRequest)
 );
 
 // Interim trigger to update billings to confirmed if date has passed

--- a/src/services/wallet.service.ts
+++ b/src/services/wallet.service.ts
@@ -1,19 +1,21 @@
+import httpStatusCodes from 'http-status-codes';
 import { Op } from 'sequelize';
 import { WITHDRAWAL_DAYS } from '../constants/constants';
 import {
+  APPROVAL_STATUS,
   BILLING_STATUS,
   BILLING_TYPE,
   USER_TYPE_ENUM,
 } from '../constants/enum';
-import { WALLET_ERROR } from '../constants/errors';
+import { ERRORS, WALLET_ERROR } from '../constants/errors';
 import { Admin } from '../models/Admin';
 import { Billing } from '../models/Billing';
 import { Course } from '../models/Course';
+import { MentorshipContract } from '../models/MentorshipContract';
 import { MentorshipListing } from '../models/MentorshipListing';
+import { RefundRequest } from '../models/RefundRequest';
 import { User } from '../models/User';
 import { Wallet } from '../models/Wallet';
-import EmailService from './email.service';
-import PaypalService from './paypal.service';
 export default class WalletService {
   // ============================== Billings ==============================
   public static async createOrderBilling(
@@ -185,74 +187,168 @@ export default class WalletService {
       include: [{ model: Wallet }],
     });
   }
-  // ============================== Withdrawals ==============================
 
-  public static async approveWithdrawal(billingId: string) {
-    const existingApplication = await Billing.findByPk(billingId);
-    if (
-      !existingApplication ||
-      existingApplication.billingType !== BILLING_TYPE.WITHDRAWAL
-    )
-      throw new Error(WALLET_ERROR.MISSING_BILLING);
-
-    if (existingApplication.status !== BILLING_STATUS.PENDING_WITHDRAWAL) {
-      throw new Error(WALLET_ERROR.PAID_OUT);
-    }
-
-    const sensei = await User.findOne({
-      where: { walletId: existingApplication.receiverWalletId },
-    });
-    const payout_json = await PaypalService.createPayout(
-      existingApplication,
-      sensei.email
-    );
-
-    return { payout_json, billing: existingApplication };
-  }
-
-  public static async postWithdrawalHelper(
-    billing: Billing,
-    paymentId: string
+  // ============================== Refunds ==============================
+  public static async cancelRefundRequest(
+    refundRequestId: string,
+    accountId: string
   ) {
-    const wallet = await Wallet.findByPk(billing.receiverWalletId);
-    const receiver = await User.findByPk(wallet.accountId);
+    const existingRefund = await RefundRequest.findByPk(refundRequestId);
+    if (!existingRefund) throw new Error(WALLET_ERROR.MISSING_REFUND_REQUEST);
+    if (existingRefund.studentId !== accountId)
+      throw new Error(
+        httpStatusCodes.getStatusText(httpStatusCodes.UNAUTHORIZED)
+      );
 
-    await billing.update({
-      paypalPaymentId: paymentId,
-      status: BILLING_STATUS.WITHDRAWN,
-    });
-
-    const newAmount = wallet.confirmedAmount - billing.amount;
-
-    await wallet.update({
-      confirmedAmount: newAmount,
-    });
-
-    await EmailService.sendEmail(receiver.email, 'withdrawalSuccess');
+    return await existingRefund.destroy();
   }
 
-  public static async rejectWithdrawal(billingId: string) {
-    const existingApplication = await Billing.findByPk(billingId);
-    if (
-      !existingApplication ||
-      existingApplication.billingType !== BILLING_TYPE.WITHDRAWAL
-    )
-      throw new Error(WALLET_ERROR.MISSING_BILLING);
+  public static async requestRefund(
+    contractId: string,
+    contractType: string,
+    accountId: string
+  ) {
+    try {
+      const user = await User.findByPk(accountId);
+      if (!user) throw new Error(ERRORS.STUDENT_DOES_NOT_EXIST);
 
-    if (existingApplication.status !== BILLING_STATUS.PENDING_WITHDRAWAL) {
-      throw new Error(WALLET_ERROR.PAID_OUT);
+      // Today - 120 days to be compared against createdAt; if createdAt is > today - 120 then it is still refundable
+      const refundablePeriod = new Date();
+      refundablePeriod.setDate(refundablePeriod.getDate() - WITHDRAWAL_DAYS);
+
+      if (contractType === BILLING_TYPE.COURSE)
+        return await this.requestCourseRefund(
+          contractId,
+          user,
+          refundablePeriod
+        );
+
+      return await this.requestMentorPassRefund(
+        contractId,
+        user,
+        refundablePeriod
+      );
+    } catch (e) {
+      throw e;
+    }
+  }
+
+  public static async requestCourseRefund(
+    contractId: string,
+    user: User,
+    refundablePeriod: Date
+  ) {
+    const accountId = user.accountId;
+
+    const existingRefund = await RefundRequest.findOne({
+      where: { contractId, studentId: accountId },
+    });
+
+    if (existingRefund) {
+      if (existingRefund.approvalStatus === APPROVAL_STATUS.APPROVED) {
+        throw new Error(WALLET_ERROR.REFUNDED); // alr refund
+      }
+      throw new Error(WALLET_ERROR.EXISTING_REFUND); // pending refund
     }
 
-    const billing = await Billing.findByPk(billingId);
-    const wallet = await Wallet.findByPk(billing.receiverWalletId);
-    const receiver = await User.findByPk(wallet.accountId);
+    const billing = await Billing.findOne({
+      where: {
+        contractId,
+        senderWalletId: user.walletId,
+        status: BILLING_STATUS.PAID,
+        billingType: BILLING_TYPE.COURSE,
+      },
+    });
 
-    await EmailService.sendEmail(receiver.email, 'withdrawalFailure');
-    return await existingApplication.update({
-      status: BILLING_STATUS.REJECTED,
+    if (billing.createdAt < refundablePeriod)
+      throw new Error(WALLET_ERROR.REFUND_PERIOD_OVER);
+
+    const refundRequest = await new RefundRequest({
+      contractId,
+      studentId: accountId,
+      contractType: BILLING_TYPE.COURSE,
+    }).save();
+
+    return await RefundRequest.findOne({
+      where: { refundRequestId: refundRequest.refundRequestId },
+      include: [
+        {
+          model: Billing,
+          as: 'OriginalBillings',
+          on: { billingId: billing.billingId },
+          include: [{ model: Course, as: 'Course' }],
+        },
+      ],
     });
   }
 
+  public static async requestMentorPassRefund(
+    contractId: string,
+    user: User,
+    refundablePeriod: Date
+  ) {
+    const accountId = user.accountId;
+
+    const existingRefunds = await RefundRequest.findAll({
+      where: { contractId, studentId: accountId },
+      order: [['createdAt', 'DESC']],
+    });
+
+    const mentorshipContract = await MentorshipContract.findByPk(contractId);
+
+    if (existingRefunds.length >= 1) {
+      const latestRefundRequest = existingRefunds[0];
+      if (
+        latestRefundRequest.approvalStatus === APPROVAL_STATUS.APPROVED &&
+        mentorshipContract.mentorPassCount === 0
+      ) {
+        throw new Error(WALLET_ERROR.REFUNDED); // alr refund
+      }
+      if (latestRefundRequest.approvalStatus === APPROVAL_STATUS.PENDING)
+        throw new Error(WALLET_ERROR.EXISTING_REFUND); // pending refund
+    }
+
+    const paidBillings = await Billing.findAll({
+      where: {
+        contractId,
+        status: BILLING_STATUS.PAID,
+        billingType: BILLING_TYPE.MENTORSHIP,
+      },
+      order: [['createdAt', 'DESC']],
+    });
+
+    let billingIds: string[] = [];
+    let remainingNumPasses = mentorshipContract.mentorPassCount;
+    for (let i = 0; i < paidBillings.length; i++) {
+      if (remainingNumPasses <= 0) break;
+      const billing = paidBillings[i];
+      if (billing.createdAt < refundablePeriod) break;
+      remainingNumPasses -= billing.mentorPassCount;
+      billingIds.push(billing.billingId);
+    }
+
+    if (billingIds.length === 0)
+      throw new Error(WALLET_ERROR.REFUND_PERIOD_OVER);
+
+    const refundRequest = await new RefundRequest({
+      contractId,
+      studentId: accountId,
+      contractType: BILLING_TYPE.MENTORSHIP,
+    }).save();
+
+    return await RefundRequest.findOne({
+      where: { refundRequestId: refundRequest.refundRequestId },
+      include: [
+        {
+          model: Billing,
+          as: 'OriginalBillings',
+          on: { billingId: { [Op.in]: billingIds } },
+          include: [{ model: MentorshipListing, as: 'MentorshipListing' }],
+        },
+      ],
+    });
+  }
+  // ============================== Withdrawals ==============================
   public static async withdrawBalance(walletId: string, accountId: string) {
     const user = await User.findByPk(accountId);
     const admin = await Admin.findOne({


### PR DESCRIPTION
### Changelog:
## Description:
- Review AFTER #304 
- Shifted all approve/reject stuff to paypal controller for finance (removed from admin controller so that the controllers that called paypal function would be centralised in paypal controller)
- Shifted functions between wallet and paypal on the basis of - whether it is an approve/reject; if it is then it will be in paypal controller. Reject doesn't actually hit paypal endpoint but it seemed better to keep reject with approve. The relevant service functions also got shifted to pretty much follow their controller functions. This means that Wallet is able to stay mainly focused on internal stuff, which it should be
## Checklist:
- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):
