### PR TITLE
include User attributes for search result (mentorship/courses)

### DIFF
--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -39,6 +39,12 @@ export default class SearchService {
           [Op.like]: `%${query}%`,
         },
       },
+      include: [
+        {
+          model: User,
+          attributes: ['firstName', 'lastName', 'profileImgUrl'],
+        },
+      ],
     });
     if (mentorshipResults.length === 0) {
       return [];
@@ -53,6 +59,12 @@ export default class SearchService {
         },
         adminVerified: ADMIN_VERIFIED_ENUM.ACCEPTED,
       },
+      include: [
+        {
+          model: User,
+          attributes: ['firstName', 'lastName', 'profileImgUrl'],
+        },
+      ],
     });
     if (courseResults.length === 0) {
       return [];


### PR DESCRIPTION
### Description:

add support for return value of Sensei (User) when querying for Mentorship/Courses to display the firstName/lastName of the user & profile pic if any.

## Changelog:

add User include in query

## Checklist:
- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):
