### PR TITLE
Bugfix: getAllTestimonials (of a single sensei)

### DIFF
--- a/src/services/mentorship.service.ts
+++ b/src/services/mentorship.service.ts
@@ -714,11 +714,27 @@ export default class MentorshipService {
   public static async getAllTestimonials(accountId: string) {
     const user = await User.findByPk(accountId);
     if (!user) throw new Error(ERRORS.USER_DOES_NOT_EXIST);
-
-    return Testimonial.findAll({
+    const mentorshipListings = await MentorshipListing.findAll({
       where: {
         accountId,
       },
+    });
+
+    const mentorshipListingIds = mentorshipListings.map(
+      (ml) => ml.mentorshipListingId
+    );
+
+    const mentorshipContracts = await MentorshipContract.findAll({
+      where: { mentorshipListingId: { [Op.in]: mentorshipListingIds } },
+    });
+
+    const mentorshipContractIds = mentorshipContracts.map(
+      (mc) => mc.mentorshipContractId
+    );
+
+    return await Testimonial.findAll({
+      where: { mentorshipContractId: { [Op.in]: mentorshipContractIds } },
+      include: [MentorshipContract, User],
     });
   }
 


### PR DESCRIPTION
### Changelog:
- see commit

## Description:
add back logic to find related mentorship listings and then mentorship contracts of a sensei since the accountId in a testimonial record belongs to the student
- has been tested on FE and it works as intended

related to https://github.com/ianleck/is4103-backend/pull/324
<img width="1276" alt="Screenshot 2021-04-13 at 12 09 44 AM" src="https://user-images.githubusercontent.com/41737751/114428777-32ff1900-9bef-11eb-8d54-f1dd09dd026d.png">

this is the route which uses this function
<img width="710" alt="Screenshot 2021-04-13 at 12 30 02 AM" src="https://user-images.githubusercontent.com/41737751/114428986-70fc3d00-9bef-11eb-92e7-440fdbe508e2.png">

## Checklist:
- [x] Merged latest develop
- [x] PR title makes sense
